### PR TITLE
[OPS-4309] Wait for dockerd termination

### DIFF
--- a/charts/drone-runner-docker/templates/deployment.yaml
+++ b/charts/drone-runner-docker/templates/deployment.yaml
@@ -53,11 +53,24 @@ spec:
                 exit 0
               }
 
+              get_running_containers() {
+                local count=$(DOCKER_HOST=tcp://localhost:2375 docker ps -q | wc -l)
+                count=$(echo "$count" | tr -d '[:space:]')
+                echo "$count"
+              }
+
               poll_for_running_containers() {
                 while true; do
-                  running_containers=$(DOCKER_HOST=tcp://localhost:2375 docker ps -q | wc -l)
-                  if [ "$running_containers" -eq 0 ]; then
-                    terminate_dockerd
+                  if [ "$(get_running_containers)" -eq 0 ]; then
+                    i=3
+                    while [ $i -gt 0 ]; do
+                      if [ "$(get_running_containers)" -eq 0 ]; then
+                        echo "Making sure no new pipeline steps (containers) are scheduled by the runner. Terminating dockerd in $i...";
+                        i=$((i-1))
+                      fi
+                      sleep 3
+                    done
+                    [ "$(get_running_containers)" -eq 0 ] && terminate_dockerd
                   else
                     echo "Containers are still running, waiting for them to stop...";
                     sleep 5


### PR DESCRIPTION
Theoretically, the `docker ps` check could happen right after a pipeline step container exits and the next one launches. In that scenario we kill the Docker daemon running in dind container and stop the pipeline execution prematurely.
Let's make sure the "no running containers" situation proves to be true over a period of time greater than a couple of milliseconds.

Output:
```
❯ docker run --rm --entrypoint "/bin/sh" airbus:latest -c "sleep 10" &
[1] 6397

❯ poll_for_running_containers
Containers are still running, waiting for them to stop...
Containers are still running, waiting for them to stop...
[1]  + done       docker run --rm --entrypoint "/bin/sh" airbus:latest -c "sleep 10"
Making sure no new pipeline steps (containers) are scheduled by the runner. Terminating dockerd in 3...
Making sure no new pipeline steps (containers) are scheduled by the runner. Terminating dockerd in 2...
Making sure no new pipeline steps (containers) are scheduled by the runner. Terminating dockerd in 1...
No running containers, shutting down dockerd
```